### PR TITLE
Renamed SEEK_cWebAuthenticationInformation CIM class in cWebApplication Resource

### DIFF
--- a/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebAppAndPool/SEEK_cWebAppAndPool.schema.psm1
+++ b/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebAppAndPool/SEEK_cWebAppAndPool.schema.psm1
@@ -36,7 +36,7 @@
             Website = $website
             WebAppPool =  $AppPoolName
             PhysicalPath = $PhysicalPath
-            AuthenticationInfo = SEEK_cWebAuthenticationInformation
+            AuthenticationInfo = SEEK_cWebApplicationAuthenticationInformation
                                 {
                                     Anonymous = $AuthenticationInfo.Anonymous
                                     Basic = $AuthenticationInfo.Basic

--- a/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.psm1
+++ b/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.psm1
@@ -306,7 +306,7 @@ function Get-AuthenticationInfo
         $authenticationProperties[$type] = [string](Test-AuthenticationEnabled -Website $Website -ApplicationName $Name -Type $type)
     }
 
-    return New-CimInstance -ClassName SEEK_cWebAuthenticationInformation -ClientOnly -Property $authenticationProperties
+    return New-CimInstance -ClassName SEEK_cWebApplicationAuthenticationInformation -ClientOnly -Property $authenticationProperties
 }
 
 function Test-AuthenticationInfo
@@ -366,7 +366,7 @@ function Set-AuthenticationInfo
 
 function Get-DefaultAuthenticationInfo
 {
-    New-CimInstance -ClassName SEEK_cWebAuthenticationInformation `
+    New-CimInstance -ClassName SEEK_cWebApplicationAuthenticationInformation `
         -ClientOnly `
         -Property @{Anonymous="false";Basic="false";Digest="false";Windows="false"}
 }

--- a/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.schema.mof
+++ b/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.schema.mof
@@ -1,5 +1,5 @@
 [ClassVersion("1.0.0")]
-Class SEEK_cWebAuthenticationInformation
+Class SEEK_cWebApplicationAuthenticationInformation
 {
     [write,ValueMap{"true", "false"},Values{"true", "false"}]string Anonymous;
     [write,ValueMap{"true", "false"},Values{"true", "false"}]string Basic;
@@ -16,8 +16,8 @@ class SEEK_cWebApplication : OMI_BaseResource
     [Write, Description("Physical path for the web application directory")] string PhysicalPath;
     [Write, Description("Whether web application should be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [write] string SslFlags;
-    [write, EmbeddedInstance("SEEK_cWebAuthenticationInformation"), Description("Hashtable containing authentication information (Anonymous, Basic, Digest, Windows)")] string AuthenticationInfo;
-    [write, Description("A comma seperated list of protocols, for example: http,net.msmq")] string EnabledProtocols;
+    [write, EmbeddedInstance("SEEK_cWebApplicationAuthenticationInformation"), Description("Hashtable containing authentication information (Anonymous, Basic, Digest, Windows)")] string AuthenticationInfo;
+    [write, Description("A comma separated list of protocols, for example: http,net.msmq")] string EnabledProtocols;
     [write, ValueMap{"All", "Custom", "Disable"}, Values{"All", "Custom", "Disable"}] string AutoStartMode;
 };
 

--- a/Tests/E2E/SEEK_cWebAdministration/SEEK_cWebAdministration.Tests.ps1
+++ b/Tests/E2E/SEEK_cWebAdministration/SEEK_cWebAdministration.Tests.ps1
@@ -70,7 +70,7 @@ Configuration TestConfiguration
             WebAppPool = "Test"
             PhysicalPath = "C:\Temp\TestApplication"
             Ensure = "Present"
-            AuthenticationInfo = SEEK_cWebAuthenticationInformation
+            AuthenticationInfo = SEEK_cWebApplicationAuthenticationInformation
                                 {
                                     Anonymous = "true"
                                     Basic = "false"

--- a/Tests/Unit/SEEK_cWebApplication/SEEK_cWebApplication.Tests.ps1
+++ b/Tests/Unit/SEEK_cWebApplication/SEEK_cWebApplication.Tests.ps1
@@ -87,7 +87,7 @@ Describe "Test-TargetResource" {
                 -ParameterFilter { ($Type -eq "Anonymous") }
             Mock Test-AuthenticationEnabled { return $true } `
                 -ParameterFilter { ($Type -eq "Windows") }
-            $authInfo = New-CimInstance -ClassName SEEK_cWebAuthenticationInformation -ClientOnly -Property @{Anonymous="true";Basic="false";Digest="false";Windows="true"}
+            $authInfo = New-CimInstance -ClassName SEEK_cWebApplicationAuthenticationInformation -ClientOnly -Property @{Anonymous="true";Basic="false";Digest="false";Windows="true"}
             Test-TargetResource -Website "MySite" -Name "MyApp" -Ensure "Present" -WebAppPool "MyAppPool" -PhysicalPath "C:\App" -AuthenticationInfo $authInfo | Should Be $true
         }
 
@@ -96,7 +96,7 @@ Describe "Test-TargetResource" {
                 -ParameterFilter { ($Type -eq "Anonymous") }
             Mock Test-AuthenticationEnabled { return $false } `
                 -ParameterFilter { ($Type -eq "Windows") }
-            $authInfo = New-CimInstance -ClassName SEEK_cWebAuthenticationInformation -ClientOnly -Property @{Anonymous="true";Basic="false";Digest="false";Windows="true"}
+            $authInfo = New-CimInstance -ClassName SEEK_cWebApplicationAuthenticationInformation -ClientOnly -Property @{Anonymous="true";Basic="false";Digest="false";Windows="true"}
             Test-TargetResource -Website "MySite" -Name "MyApp" -Ensure "Present" -WebAppPool "MyAppPool" -PhysicalPath "C:\App" -AuthenticationInfo $authInfo | Should Be $false
         }
     }


### PR DESCRIPTION
Renamed `SEEK_cWebAuthenticationInformation` CIM class to `SEEK_cWebApplicationAuthenticationInformation` in the `cWebApplication` resource as it conflicts with a class of the same name in the `cWebsite` resource. Addresses issue #20.

This is a backwards-incompatible change for anyone using `cWebApplication`.