### PR TITLE
remove noisy deprecation warnings from logs

### DIFF
--- a/Tools/chocolateyInstall.ps1
+++ b/Tools/chocolateyInstall.ps1
@@ -18,9 +18,7 @@ try
 		Get-ChildItem -Path "$DSCResourcesRoot\$_" -File -Recurse | Unblock-File
 	}
 
-	Write-ChocolateySuccess 'SEEK PowerShell DSC Resources'
 } catch {
-	Write-ChocolateyFailure 'SEEK PowerShell DSC Resources' $($_.Exception.Message)
 	$host.SetShouldExit(1)
-	throw $_
+	throw $_.Exception
 }

--- a/Tools/chocolateyUninstall.ps1
+++ b/Tools/chocolateyUninstall.ps1
@@ -3,9 +3,6 @@ try
 	$DSCResourcesRoot = Join-Path $env:ProgramFiles "WindowsPowerShell\Modules"
 	$DSCResourceTarget = Join-Path $env:chocolateyPackageFolder "lib"
 	Get-ChildItem $DSCResourceTarget | Foreach-Object { cmd /c rmdir "$DSCResourcesRoot\$_" }
-
-	Write-ChocolateySuccess 'SEEK PowerShell DSC Resources'
 } catch {
-	Write-ChocolateyFailure 'SEEK PowerShell DSC Resources' $($_.Exception.Message)
-	throw $_
+    throw $_.Exception
 }


### PR DESCRIPTION
Would like to remove chatter from the logs. So removed calls to Write-ChocolateyFailure and Write-ChocolateySuccess 

Implemented failure and success of choco install scripts as per deprecation notice https://github.com/chocolatey/chocolatey/wiki/HelpersWriteChocolateySuccess and https://github.com/chocolatey/chocolatey/wiki/HelpersWriteChocolateyFailure.

And a comment can be seen here
https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/Write-ChocolateyFailure.ps1 and https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/helpers/functions/Write-ChocolateySuccess.ps1