### PR TITLE
Recommit fix based on Master branch not V2 branch

### DIFF
--- a/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.psm1
+++ b/Modules/SEEK - Modules/cWebAdministration/DSCResources/SEEK_cWebApplication/SEEK_cWebApplication.psm1
@@ -107,7 +107,7 @@ function Set-TargetResource
             Set-WebConfiguration -Location "${Website}/${Name}" -Filter 'system.webserver/security/access' -Value $SslFlags
 
             if ($EnabledProtocols) {
-                Set-ItemProperty -Path $webappPath -Name EnabledProtocols -Value $EnabledProtocols
+                Set-ItemProperty -Path $webappPath -Name enabledProtocols -Value $EnabledProtocols
             }
         }
         elseif (($Ensure -eq "Absent") -and ($webApplication -ne $null))


### PR DESCRIPTION
as per https://github.com/SEEK-Jobs/DSC/pull/30

Resubmitted from the master branch

This is the behavior:

```
PS C:\Users\jbaker\AppData\Local\Temp\2> Get-ItemProperty -Path IIS:\Sites\seek.adcentre.daemon\Server  | select EnabledProto*

enabledProtocols
----------------
http           

PS C:\Users\jbaker\AppData\Local\Temp\2> Set-ItemProperty -Path IIS:\Sites\seek.adcentre.daemon\Server -Name EnabledProtocols -Value 'http,net.msmq'

PS C:\Users\jbaker\AppData\Local\Temp\2> Get-ItemProperty -Path IIS:\Sites\seek.adcentre.daemon\Server  | select EnabledProto*

enabledProtocols
----------------
http            

PS C:\Users\jbaker\AppData\Local\Temp\2> Set-ItemProperty -Path IIS:\Sites\seek.adcentre.daemon\Server -Name enabledProtocols -Value 'http,net.msmq'

PS C:\Users\jbaker\AppData\Local\Temp\2> Get-ItemProperty -Path IIS:\Sites\seek.adcentre.daemon\Server  | select EnabledProto*

enabledProtocols
----------------
http,net.msmq
```

I have changed the case to lower as well as keeping other cases consistent.

Pester tests also all passed:

```
\\d2251-w10\c$\Users\jbaker\Git\Github\SEEK-Jobs-DSC\Tests\Unit\SEEK_cWebApplication [jb-fix-24072015]> Invoke-Pester

Describing Get-TargetResource
   Context when the web application is present
    [+] returns the web application state as a hashtable 184ms
   Context when the web application is absent
    [+] returns an absent web application hashtable 247ms
Describing Test-TargetResource
   Context when the web application is present
    [+] returns true if the web application should be present 149ms
    [+] returns false if the web application should be absent 46ms
    [+] returns false if the web application pool is different 36ms
    [+] returns false if the physical path is different 87ms
    [+] returns true if the enabled protocols are the same 74ms
    [+] returns false if the enabled protocols differ 102ms
    [+] returns true if the authentication info is the same 128ms
    [+] returns false if the authentication info is different 74ms
   Context when the web application is absent
    [+] returns false if the web application should be present 38ms
    [+] returns true if the web application should be absent 21ms
Describing Set-TargetResource
   Context when the web application is absent
    [+] installs the web application 132ms
    [+] sets the enabled protocols, if provided 59ms
   Context when the web application is present
    [+] does nothing 92ms
   Context when configuration specifies the web application should be absent
    [+] removes the web application if the web application is present 66ms
Tests completed in 1.54s
Passed: 16 Failed: 0 Skipped: 0 Pending: 0
```